### PR TITLE
Updated/removed links pointing to wstools instead of wstools-py3.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,40 +2,24 @@
 WSDL parsing services package for Web Services for Python
 =========================================================
 
-.. image:: https://img.shields.io/pypi/pyversions/wstools.svg
-        :target: https://pypi.python.org/pypi/wstools/
+.. image:: https://img.shields.io/pypi/pyversions/wstools-py3.svg
+        :target: https://pypi.python.org/pypi/wstools-py3/
 
-.. image:: https://img.shields.io/github/license/pycontribs/wstools.svg
-        :target: https://pypi.python.org/pypi/wstools/
+.. image:: https://img.shields.io/github/license/Synerty/wstools-py3.svg
+        :target: https://pypi.python.org/pypi/wstools-py3/
 
-.. image:: https://img.shields.io/pypi/dm/wstools.svg
-        :target: https://pypi.python.org/pypi/wstools/
-
-.. image:: https://img.shields.io/pypi/wheel/wstools.svg
-        :target: https://pypi.python.org/pypi/wstools/
-
+		
 ------------
 
-.. image:: https://api.travis-ci.org/pycontribs/wstools.svg?branch=develop
-        :target: https://travis-ci.org/pycontribs/wstools
-
-.. image:: https://img.shields.io/pypi/status/wstools.svg
-        :target: https://pypi.python.org/pypi/wstools/
-
-.. image:: https://img.shields.io/coveralls/pycontribs/wstools.svg
-        :target: https://coveralls.io/r/pycontribs/wstools
-
-.. image:: http://api.flattr.com/button/flattr-badge-large.png
-        :target: https://flattr.com/submit/auto?user_id=sbarnea&url=https://github.com/pycontribs/wstools&title=Python wstools&language=&tags=github&category=software
+.. image:: https://img.shields.io/pypi/status/wstools-py3.svg
+        :target: https://pypi.python.org/pypi/wstools-py3/
 
 
 General
 =======
 
--  Homepage: https://github.com/pycontribs/wstools
--  Mailing List: https://groups.google.com/forum/#!forum/pycontribs
--  Package: http://pypi.python.org/pypi/wstools/
--  Docs (TBD): http://packages.python.org/wstools
+-  Homepage: https://github.com/Synerty/wstools-py3
+-  Package: http://pypi.python.org/pypi/wstools-py3/
 
 Credits
 =======
@@ -60,8 +44,3 @@ Contributors
 ------------
 
 -  Sorin Sbarnea sorin.sbarnea@gmail.com
-
-.. |Build Status| image:: https://travis-ci.org/kartoch/wstools.svg?branch=master
-   :target: https://travis-ci.org/kartoch/wstools
-.. |Coverage Status| image:: https://img.shields.io/coveralls/kartoch/wstools.svg
-   :target: https://coveralls.io/r/kartoch/wstools?branch=master


### PR DESCRIPTION
Removed broken links and corrected other links to point to the wstools-py3.

This looks very similar to what is on Pypi, so I hope it will be put there too - it mispointed me first to wstools, so here is a fix also for others.