### PR TITLE
Move to collections.abc

### DIFF
--- a/wstools/Utility.py
+++ b/wstools/Utility.py
@@ -33,7 +33,7 @@ try:
     from UserDict import DictMixin  # noqa
 except ImportError:
     from collections import UserDict
-    from collections import MutableMapping as DictMixin  # noqa
+    from collections.abc import MutableMapping as DictMixin  # noqa
 
 from .TimeoutSocket import TimeoutSocket, TimeoutError  # noqa
 


### PR DESCRIPTION
The abstract classes of collections were moved to collections.abc in 3.3 and aliases were removed in 3.10.